### PR TITLE
JCN-148-corregir-documentacion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `README.md` Parameters order for `add` method
 
 ## [1.0.0] - 2019-08-07
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ npm install @janiscommerce/log
 ```
 
 ## API
-- `add(log, bucketName)`  
-Parameters: `log [Object]`, `bucketName [String]`  
+- `add(bucketName, log)`  
+Parameters: `bucketName [String]`, `log [Object]`  
 Puts the recieved log into the specified S3 bucket.
 
 - `on(event, callback)`  

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ In case of error while creating your log into S3, this package will emit an even
 ```js
 const Log = require('@janiscommerce/log');
 
-Log.add({
+Log.add('my-bucket', {
 	type: 1,
 	entity: 'api',
 	entity_id: 'product',
 	message: '[GET] Request from 0.0.0.0 of custom_data'
 	// ...
-}, 'my-bucket');
+});
 
 Log.on('create-error', (log, err) => {
 	console.error(`An error occurred while creating the log ${err.message}`);


### PR DESCRIPTION
**JCN-148-CORREGIR-DOCUMENTACION**
JCN-148 corregir documentación

**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-148

**DESCRIPCIÓN DEL REQUERIMIENTO**
2.1 Cambiar el orden de los parámetros que recibe, en vez de `(log, bucket)` deberia ir `(bucket, log)`

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se corrigió la documentación