### PR TITLE
JTR-54-CAMBIO-DE-PATH-EN-S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- `service` field support, will use it if exists, or will use ENV service name otherwise.
+
+### Changed
+- log S3 key/path now includes `service` and `entity` prefixes
+
 ## [1.2.0] - 2019-10-11
 ### Added
 - target bucket stage is obtained from `JANIS_ENV` environment variable

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Puts the recieved log into the janis-trace-service bucket using the `clientCode`
 
 ### Log structure
 The `log [Object]` parameter have the following structure:
+- **`service [String]`** (optional): The service name, if this field not exists, will be obtained from the ENV (**`JANIS_SERVICE_NAME`**)
 - **`type [String|Number]`** (required): The log type
 - **`entity [String]`** (required): The name of the entity that is creating the log
 - **`entity_id [String]`** (optional): The ID of the entity that is creating the log

--- a/lib/log.js
+++ b/lib/log.js
@@ -70,8 +70,13 @@ class Log {
 
 	static async _add(client, log) {
 
-		if(typeof this._serviceName === 'undefined')
-			throw new LogError('Unknown service name', LogError.codes.NO_SERVICE_NAME);
+		if(typeof log.service === 'undefined') {
+
+			if(typeof this._serviceName === 'undefined')
+				throw new LogError('Unknown service name', LogError.codes.NO_SERVICE_NAME);
+
+			log.service = this._serviceName;
+		}
 
 		if(typeof client !== 'string')
 			throw new LogError('Invalid or empty client', LogError.codes.INVALID_CLIENT);
@@ -92,8 +97,8 @@ class Log {
 
 		return S3.putObject({
 			Bucket: this.bucket,
-			Key: `${client}/${year}/${month}/${day}/${log.id}.json`,
-			Body: JSON.stringify({ ...log, service: this._serviceName }),
+			Key: `${client}/${year}/${month}/${day}/${log.service}/${log.entity}/${log.id}.json`,
+			Body: JSON.stringify(log),
 			ContentType: 'application/json'
 		}).promise();
 	}
@@ -103,6 +108,10 @@ class Log {
 		// Log should be an object (not array)
 		if(typeof log !== 'object' || Array.isArray(log))
 			throw new LogError('Invalid log: should be an object', LogError.codes.INVALID_LOG);
+
+		// Should have service property with type string
+		if(typeof log.service !== 'string')
+			throw new LogError('Invalid log: should have a valid service name and must be a string', LogError.codes.INVALID_LOG);
 
 		// Should have entity property with type string
 		if(typeof log.entity !== 'string')


### PR DESCRIPTION
**JTR-54-CAMBIO-DE-PATH-EN-S3**
JTR-54 Cambio de path del S3 en package Log

**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JTR-54

**DESCRIPCIÓN DEL REQUERIMIENTO**
Cambiar la key actual a la nueva `s3://janis-trace-service-{env}/{clientCode}/{YYYY}/{MM}/{DD}/{serviceCode}/{entity}/{log-id}.json`

El dato service ahora deberá poder llegar en el object log

Cuando este dato llegue, se deberá usar como prioritario, en caso de no llegar, se deberá seguir usando la variable de entorno `JANIS_SERVICE_NAME`

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se desarrollaron los requerimientos solicitados