### PR TITLE
JTR-57 firehose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Uploading logs to Firehose instead S3
 - Log `type` field now can be only a string, not a number
+- Snake_case fields deprecated, only camelCase
 
 ## [2.0.0] - 2019-12-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Log struct and formatting
+
+### Changed
+- Uploading logs to Firehose instead S3
+- Log `type` field now can be only a string, not a number
+
 ## [2.0.0] - 2019-12-05
 ### Added
 - `service` field support, will use it if exists, or will use ENV service name otherwise.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The codes are the following:
 | Code | Description                    |
 |------|--------------------------------|
 | 1    | Invalid log                    |
-| 2    | S3 Error                       |
+| 2    | Firehose Error                 |
 | 3    | Unknown stage name             |
 
 In case of error while creating your log into S3, this package will emit an event called `create-error`, you can handle it using the `on()` method.

--- a/README.md
+++ b/README.md
@@ -86,11 +86,3 @@ Log.on('create-error', (log, err) => {
 	console.error(`An error occurred while creating the log ${err.message}`);
 });
 ```
-
-## Notes
-In order to connect into Firehose, this package requires the aws volume in the `docker-compose.yml`.
-
-```yml
-volumes:
-  ~/.aws:/root/.aws
-```

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The `log [Object]` parameter have the following structure:
 - **`service [String]`** (optional): The service name, if this field not exists, will be obtained from the ENV (**`JANIS_SERVICE_NAME`**)
 - **`type [String]`** (required): The log type
 - **`entity [String]`** (required): The name of the entity that is creating the log
-- **`entity_id [String]`** (optional): The ID of the entity that is creating the log
+- **`entityId [String]`** (optional): The ID of the entity that is creating the log
 - **`message [String]`** (optional): A general message about the log
 - **`log [Object|Array]`** (optional): This property is a JSON that includes all the technical data about your log.
 
@@ -77,7 +77,7 @@ const Log = require('@janiscommerce/log');
 Log.add('some-client', {
 	type: 1,
 	entity: 'api',
-	entity_id: 'product',
+	entityId: 'product',
 	message: '[GET] Request from 0.0.0.0 of custom_data'
 	// ...
 });

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/janis-commerce/log.svg?branch=master)](https://travis-ci.org/janis-commerce/log)
 [![Coverage Status](https://coveralls.io/repos/github/janis-commerce/log/badge.svg?branch=master)](https://coveralls.io/github/janis-commerce/log?branch=master)
 
-A package for creating logs in S3
+A package for creating logs in Firehose
 
 ## Installation
 ```sh
@@ -18,22 +18,22 @@ npm install @janiscommerce/log
 ## API
 ### **`add(clientCode, log)`**  
 Parameters: `clientCode [String]`, `log [Object]`  
-Puts the recieved log into the janis-trace-service bucket using the `clientCode` as key prefix.
+Puts the recieved log into the janis-trace-firehose
 
 ### Log structure
 The `log [Object]` parameter have the following structure:
+- **`id [String]`** (optional): The ID of the log in UUID V4 format. Default will be auto-generated.
 - **`service [String]`** (optional): The service name, if this field not exists, will be obtained from the ENV (**`JANIS_SERVICE_NAME`**)
-- **`type [String|Number]`** (required): The log type
+- **`type [String]`** (required): The log type
 - **`entity [String]`** (required): The name of the entity that is creating the log
 - **`entity_id [String]`** (optional): The ID of the entity that is creating the log
 - **`message [String]`** (optional): A general message about the log
-- **`log [Object]`** (optional): This property is a JSON that includes all the technical data about your log.
-- **`date_created [unix_timestamp]`** (optional): The date created of the log. Default will be auto-generated.
-- **`id [String]`** (optional): The ID of the log in UUID V4 format. Default will be auto-generated.
+- **`log [Object|Array]`** (optional): This property is a JSON that includes all the technical data about your log.
 
 ### Log example
 ```js
 {
+  id: '0acefd5e-cb90-4531-b27a-e4d236f07539',
   type: 'new',
   entity: 'api',
   entity_id: 'log',
@@ -45,11 +45,10 @@ The `log [Object]` parameter have the following structure:
     headers: {
       'x-forwarded-for': '12.345.67.89',
       'x-forwarded-proto': 'https',
-      'x-forwarded-port': '443',
+      'x-forwarded-port': '443'
     },
     responseHttpCode: 200
-  },
-  id: '0acefd5e-cb90-4531-b27a-e4d236f07539'
+  }
 }
 ```
 
@@ -66,10 +65,8 @@ The codes are the following:
 | Code | Description                    |
 |------|--------------------------------|
 | 1    | Invalid log                    |
-| 2    | Invalid client                 |
-| 3    | S3 Error                       |
-| 4    | Unknown service name           |
-| 5    | Unknown stage name             |
+| 2    | S3 Error                       |
+| 3    | Unknown stage name             |
 
 In case of error while creating your log into S3, this package will emit an event called `create-error`, you can handle it using the `on()` method.
 
@@ -91,7 +88,7 @@ Log.on('create-error', (log, err) => {
 ```
 
 ## Notes
-In order to connect into S3, this package requires the aws volume in the `docker-compose.yml`.
+In order to connect into Firehose, this package requires the aws volume in the `docker-compose.yml`.
 
 ```yml
 volumes:

--- a/lib/firehose-wrapper.js
+++ b/lib/firehose-wrapper.js
@@ -8,7 +8,8 @@ class FirehoseWrapper {
 		this._firehose = new Firehose(config);
 	}
 
-	/* istanbul ignore next */ // AWS generates the Firehose class on the fly, the putRecord method do not exists before creating the insance
+	/* istanbul ignore next */
+	// AWS generates the Firehose class on the fly, the putRecord method do not exists before creating the insance
 	async putRecord(record) {
 		return this._firehose.putRecord(record).promise();
 	}

--- a/lib/firehose-wrapper.js
+++ b/lib/firehose-wrapper.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const { Firehose } = require('aws-sdk');
+
+class FirehoseWrapper {
+
+	constructor(config) {
+		this._firehose = new Firehose(config);
+	}
+
+	/* istanbul ignore next */ // AWS generates the Firehose class on the fly, the putRecord method do not exists before creating the insance
+	async putRecord(record) {
+		return this._firehose.putRecord(record).promise();
+	}
+}
+
+module.exports = FirehoseWrapper;

--- a/lib/log-error.js
+++ b/lib/log-error.js
@@ -6,10 +6,8 @@ class LogError extends Error {
 
 		return {
 			INVALID_LOG: 1,
-			INVALID_CLIENT: 2,
-			S3_ERROR: 3,
-			NO_SERVICE_NAME: 4,
-			NO_STAGE_NAME: 5
+			FIREHOSE_ERROR: 2,
+			NO_ENVIRONMENT: 3
 		};
 
 	}

--- a/lib/log.js
+++ b/lib/log.js
@@ -55,7 +55,7 @@ class Log {
 	 * add('some-client', {
 	 * 	type: 'some-type',
 	 * 	entity: 'some-entity',
-	 * 	entityId: 'some-entity_id',
+	 * 	entityId: 'some-entityId',
 	 * 	message: 'some-message',
 	 * 	log: {
 	 * 		some: 'log'

--- a/lib/log.js
+++ b/lib/log.js
@@ -21,18 +21,6 @@ const emitter = new EventEmmiter();
 
 class Log {
 
-	static get deliveryStreamName() {
-
-		if(!this._deliveryStreamName)
-			this.setDeliveryStreamName();
-
-		return this._deliveryStreamName;
-	}
-
-	static set deliveryStreamName(deliveryStreamName) {
-		this._deliveryStreamName = deliveryStreamName;
-	}
-
 	static get _serviceName() {
 		return process.env.JANIS_SERVICE_NAME;
 	}
@@ -41,29 +29,96 @@ class Log {
 		return process.env.JANIS_ENV;
 	}
 
-	static setDeliveryStreamName() {
+	static get deliveryStreamName() {
 
-		if(!this._env)
-			throw new LogError('Unknown environment', LogError.codes.NO_ENVIRONMENT);
+		if(!this._deliveryStreamName)
+			this._deliveryStreamName = `${DELIVERY_STREAM_PREFIX}${this._getFormattedEnv()}`;
 
-		this.deliveryStreamName = `${DELIVERY_STREAM_PREFIX}${this._getFormattedEnv()}`;
+		return this._deliveryStreamName;
 	}
 
-	static on(event, callback) {
-		emitter.on(event, callback);
-	}
-
+	/**
+	 * Put a log into Firehose
+	 * @param {String} client The client code who created the log
+	 * @param {Object} log The log object
+	 * @example
+	 * add('some-client', {
+	 * 	type: 'some-type',
+	 * 	entity: 'some-entity',
+	 * 	entityId: 'some-entity_id',
+	 * 	message: 'some-message',
+	 * 	log: {
+	 * 		some: 'log'
+	 * 	}
+	 * });
+	 */
 	static async add(client, log) {
 
 		try {
 
-			log = this._buildLog(log, client);
+			log = this._validateLog(log, client);
 
 		} catch(err) {
 			return emitter.emit('create-error', log, err);
 		}
 
 		return this._add(log);
+	}
+
+	/**
+	 * Sets a callback for the specified event name
+	 * @param {String} event The event name
+	 * @param {Function} callback The event callback
+	 * @example
+	 * on('create-error', (log, err) => {...});
+	 */
+	static on(event, callback) {
+		emitter.on(event, callback);
+	}
+
+	static _validateLog(rawLog, client) {
+
+		const logStruct = struct.partial({
+			id: 'string',
+			service: 'string',
+			entity: 'string',
+			entityId: 'string?|number?',
+			type: 'string',
+			log: 'object?|array?',
+			message: 'string?',
+			client: 'string',
+			userCreated: 'string?'
+		}, {
+			id: UUID(),
+			service: this._serviceName,
+			client
+		});
+
+		try {
+
+			const validLog = logStruct(rawLog);
+
+			if(validLog.log)
+				validLog.log = JSON.stringify(validLog.log);
+
+			return {
+				...validLog,
+				dateCreated: new Date().toISOString()
+			};
+
+		} catch(err) {
+			throw new LogError(err.message, LogError.codes.INVALID_LOG);
+		}
+	}
+
+	static _getFormattedEnv() {
+
+		if(!this._env)
+			throw new LogError('Unknown environment', LogError.codes.NO_ENVIRONMENT);
+
+		const env = this._env[0].toUpperCase() + this._env.slice(1).toLowerCase();
+
+		return env === 'Qa' ? env.toUpperCase() : env;
 	}
 
 	static async _add(log, attempts = 1) {
@@ -86,47 +141,6 @@ class Log {
 
 			return this._add(log, ++attempts);
 		}
-	}
-
-	static _buildLog(rawLog, client) {
-
-		const logStruct = struct.partial({
-			id: 'string',
-			service: 'string',
-			entity: 'string',
-			entityId: 'string?|number?',
-			type: 'string',
-			log: 'object?|array?',
-			message: 'string?',
-			client: 'string',
-			userCreated: 'string?'
-		}, {
-			id: UUID(),
-			service: this._serviceName,
-			client
-		});
-
-
-		try {
-
-			const validLog = logStruct(rawLog);
-
-			if(validLog.log)
-				validLog.log = JSON.stringify(validLog.log);
-
-			return {
-				...validLog,
-				dateCreated: new Date().toISOString()
-			};
-
-		} catch(err) {
-			throw new LogError(err.message, LogError.codes.INVALID_LOG);
-		}
-	}
-
-	static _getFormattedEnv() {
-		const env = this._env[0].toUpperCase() + this._env.slice(1).toLowerCase();
-		return env === 'Qa' ? env.toUpperCase() : env;
 	}
 }
 

--- a/lib/log.js
+++ b/lib/log.js
@@ -29,6 +29,16 @@ class Log {
 		return process.env.JANIS_ENV;
 	}
 
+	static get _envs() {
+
+		return {
+			local: 'Local',
+			beta: 'Beta',
+			qa: 'QA',
+			prod: 'Prod'
+		};
+	}
+
 	static get deliveryStreamName() {
 
 		if(!this._deliveryStreamName)
@@ -113,15 +123,13 @@ class Log {
 
 	static _getFormattedEnv() {
 
-		if(!this._env)
-			throw new LogError('Unknown environment', LogError.codes.NO_ENVIRONMENT);
+		if(this._env && this._envs[this._env])
+			return this._envs[this._env];
 
-		const env = this._env[0].toUpperCase() + this._env.slice(1).toLowerCase();
-
-		return env === 'Qa' ? env.toUpperCase() : env;
+		throw new LogError('Unknown environment', LogError.codes.NO_ENVIRONMENT);
 	}
 
-	static async _add(log, attempts = 1) {
+	static async _add(log, attempts = 0) {
 
 		try {
 
@@ -134,12 +142,14 @@ class Log {
 
 		} catch(err) {
 
+			attempts++;
+
 			if(attempts >= MAX_ATTEMPTS) {
 				return emitter.emit('create-error', log,
 					new LogError(`Unable to put the log into firehose, max attempts reached: ${err.message}`, LogError.codes.FIREHOSE_ERROR));
 			}
 
-			return this._add(log, ++attempts);
+			return this._add(log, attempts);
 		}
 	}
 }

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,129 +1,119 @@
 'use strict';
 
+const { struct } = require('superstruct');
+
 const EventEmmiter = require('events');
-
 const UUID = require('uuid/v4');
-
-const AWS = require('aws-sdk');
 
 const LogError = require('./log-error');
 
+const Firehose = require('./firehose-wrapper');
+
 const MAX_ATTEMPTS = 3;
-
 const MAX_TIMEOUT = 500;
+const DELIVERY_STREAM_PREFIX = 'janis-trace-firehose';
 
-const BUCKET_PREFIX = 'janis-trace-service';
-
-const S3 = new AWS.S3({ httpOptions: { timeout: MAX_TIMEOUT } });
-
+const firehose = new Firehose({ httpOptions: { timeout: MAX_TIMEOUT } });
 const emitter = new EventEmmiter();
 
 class Log {
+
+	static get deliveryStreamName() {
+
+		if(!this._deliveryStreamName)
+			this.setDeliveryStreamName();
+
+		return this._deliveryStreamName;
+	}
+
+	static set deliveryStreamName(deliveryStreamName) {
+		this._deliveryStreamName = deliveryStreamName;
+	}
 
 	static get _serviceName() {
 		return process.env.JANIS_SERVICE_NAME;
 	}
 
-	static get _stage() {
+	static get _env() {
 		return process.env.JANIS_ENV;
 	}
 
-	static get bucket() {
+	static setDeliveryStreamName() {
 
-		if(!this._bucket)
-			this.setBucket();
+		if(!this._env)
+			throw new LogError('Unknown environment', LogError.codes.NO_ENVIRONMENT);
 
-		return this._bucket;
-	}
-
-	static set bucket(bucket) {
-		this._bucket = bucket;
-	}
-
-	static setBucket() {
-
-		if(typeof this._stage === 'undefined')
-			throw new LogError('Unknown stage name', LogError.codes.NO_STAGE_NAME);
-
-		this.bucket = `${BUCKET_PREFIX}-${this._stage}`;
-	}
-
-	static async add(client, log, attempts = 1) {
-
-		try {
-
-			await this._add(client, log);
-
-		} catch(err) {
-
-			if(err.name === 'LogError')
-				return emitter.emit('create-error', log, err);
-
-			if(attempts >= MAX_ATTEMPTS) {
-				return emitter.emit('create-error', log,
-					new LogError(`Unable to put the log into S3, max attempts reached: ${err.message}`, LogError.codes.S3_ERROR));
-			}
-
-			return this.add(client, log, ++attempts);
-		}
-	}
-
-	static async _add(client, log) {
-
-		if(typeof log.service === 'undefined') {
-
-			if(typeof this._serviceName === 'undefined')
-				throw new LogError('Unknown service name', LogError.codes.NO_SERVICE_NAME);
-
-			log.service = this._serviceName;
-		}
-
-		if(typeof client !== 'string')
-			throw new LogError('Invalid or empty client', LogError.codes.INVALID_CLIENT);
-
-		this._validateLog(log);
-
-		const date = log.date_created ? new Date(log.date_created * 1000) : new Date();
-		const year = date.getFullYear();
-		const month = (date.getMonth() + 1).toString().padStart(2, 0);
-		const day = date.getDate().toString()
-			.padStart(2, 0);
-
-		if(!log.date_created)
-			log.date_created = Math.floor(date / 1000);
-
-		if(!log.id)
-			log.id = UUID();
-
-		return S3.putObject({
-			Bucket: this.bucket,
-			Key: `${client}/${year}/${month}/${day}/${log.service}/${log.entity}/${log.id}.json`,
-			Body: JSON.stringify(log),
-			ContentType: 'application/json'
-		}).promise();
-	}
-
-	static _validateLog(log) {
-
-		// Log should be an object (not array)
-		if(typeof log !== 'object' || Array.isArray(log))
-			throw new LogError('Invalid log: should be an object', LogError.codes.INVALID_LOG);
-
-		// Should have service property with type string
-		if(typeof log.service !== 'string')
-			throw new LogError('Invalid log: should have a valid service name and must be a string', LogError.codes.INVALID_LOG);
-
-		// Should have entity property with type string
-		if(typeof log.entity !== 'string')
-			throw new LogError('Invalid log: should have a valid entity property and must be a string', LogError.codes.INVALID_LOG);
-
-		// Should have type property with type number or string
-		if(typeof log.type !== 'string' && typeof log.type !== 'number')
-			throw new LogError('Invalid log: should have a valid type property and must be a string or number', LogError.codes.INVALID_LOG);
+		this.deliveryStreamName = `${DELIVERY_STREAM_PREFIX}-${this._env}`;
 	}
 
 	static on(event, callback) {
 		emitter.on(event, callback);
+	}
+
+	static async add(client, log) {
+
+		try {
+
+			log = this._buildLog(log, client);
+
+		} catch(err) {
+			return emitter.emit('create-error', log, err);
+		}
+
+		return this._add(log);
+	}
+
+	static async _add(log, attempts = 1) {
+
+		try {
+
+			await firehose.putRecord({
+				DeliveryStreamName: this.deliveryStreamName,
+				Record: {
+					Data: Buffer.from(JSON.stringify(log))
+				}
+			});
+
+		} catch(err) {
+
+			if(attempts >= MAX_ATTEMPTS) {
+				return emitter.emit('create-error', log,
+					new LogError(`Unable to put the log into firehose, max attempts reached: ${err.message}`, LogError.codes.FIREHOSE_ERROR));
+			}
+
+			return this._add(log, ++attempts);
+		}
+	}
+
+	static _buildLog(log, client) {
+
+		const logStruct = struct.partial({
+			id: 'string',
+			service: 'string',
+			entity: 'string',
+			entityId: 'string?|number?',
+			type: 'string',
+			log: 'object?|array?',
+			message: 'string?',
+			client: 'string',
+			userCreated: 'string?'
+		}, {
+			id: UUID(),
+			service: this._serviceName,
+			client
+		});
+
+		try {
+
+			log = logStruct(log);
+
+		} catch(err) {
+			throw new LogError(err.message, LogError.codes.INVALID_LOG);
+		}
+
+		log.dateCreated = new Date().toISOString();
+
+		return log;
 	}
 }
 

--- a/lib/log.js
+++ b/lib/log.js
@@ -11,9 +11,12 @@ const Firehose = require('./firehose-wrapper');
 
 const MAX_ATTEMPTS = 3;
 const MAX_TIMEOUT = 500;
-const DELIVERY_STREAM_PREFIX = 'janis-trace-firehose';
+const DELIVERY_STREAM_PREFIX = 'JanisTraceFirehose';
 
-const firehose = new Firehose({ httpOptions: { timeout: MAX_TIMEOUT } });
+const firehose = new Firehose({
+	region: process.env.AWS_DEFAULT_REGION,
+	httpOptions: { timeout: MAX_TIMEOUT }
+});
 const emitter = new EventEmmiter();
 
 class Log {
@@ -43,7 +46,7 @@ class Log {
 		if(!this._env)
 			throw new LogError('Unknown environment', LogError.codes.NO_ENVIRONMENT);
 
-		this.deliveryStreamName = `${DELIVERY_STREAM_PREFIX}-${this._env}`;
+		this.deliveryStreamName = `${DELIVERY_STREAM_PREFIX}${this._getFormattedEnv()}`;
 	}
 
 	static on(event, callback) {
@@ -85,7 +88,7 @@ class Log {
 		}
 	}
 
-	static _buildLog(log, client) {
+	static _buildLog(rawLog, client) {
 
 		const logStruct = struct.partial({
 			id: 'string',
@@ -103,17 +106,27 @@ class Log {
 			client
 		});
 
+
 		try {
 
-			log = logStruct(log);
+			const validLog = logStruct(rawLog);
+
+			if(validLog.log)
+				validLog.log = JSON.stringify(validLog.log);
+
+			return {
+				...validLog,
+				dateCreated: new Date().toISOString()
+			};
 
 		} catch(err) {
 			throw new LogError(err.message, LogError.codes.INVALID_LOG);
 		}
+	}
 
-		log.dateCreated = new Date().toISOString();
-
-		return log;
+	static _getFormattedEnv() {
+		const env = this._env[0].toUpperCase() + this._env.slice(1).toLowerCase();
+		return env === 'Qa' ? env.toUpperCase() : env;
 	}
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3174,9 +3174,9 @@
       "dev": true
     },
     "superstruct": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.6.1.tgz",
-      "integrity": "sha512-LDbOKL5sNbOJ00Q36iYRhSexKIptZje0/mhNznnz04wT9CmsPDZg/K/UV1dgYuCwNMuOBHTbVROZsGB9EhhK4w==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.6.2.tgz",
+      "integrity": "sha512-lvA97MFAJng3rfjcafT/zGTSWm6Tbpk++DP6It4Qg7oNaeM+2tdJMuVgGje21/bIpBEs6iQql1PJH6dKTjl4Ig==",
       "requires": {
         "clone-deep": "^2.0.1",
         "kind-of": "^6.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@janiscommerce/log",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -363,6 +363,17 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
+    },
+    "clone-deep": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-2.0.2.tgz",
+      "integrity": "sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==",
+      "requires": {
+        "for-own": "^1.0.0",
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.0",
+        "shallow-clone": "^1.0.0"
+      }
     },
     "color-convert": {
       "version": "1.9.3",
@@ -880,6 +891,19 @@
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
     },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+    },
+    "for-own": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+      "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+      "requires": {
+        "for-in": "^1.0.1"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1210,11 +1234,24 @@
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true
     },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+    },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "requires": {
+        "isobject": "^3.0.1"
+      }
     },
     "is-promise": {
       "version": "2.1.0",
@@ -1256,6 +1293,11 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "istanbul-lib-coverage": {
       "version": "2.0.5",
@@ -1336,6 +1378,11 @@
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
       "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
       "dev": true
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "levn": {
       "version": "0.3.0",
@@ -1418,6 +1465,22 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
+    },
+    "mixin-object": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+      "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
+      "requires": {
+        "for-in": "^0.1.3",
+        "is-extendable": "^0.1.1"
+      },
+      "dependencies": {
+        "for-in": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+          "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE="
+        }
+      }
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -2939,6 +3002,23 @@
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
       "dev": true
     },
+    "shallow-clone": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-1.0.0.tgz",
+      "integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
+      "requires": {
+        "is-extendable": "^0.1.1",
+        "kind-of": "^5.0.0",
+        "mixin-object": "^2.0.1"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+        }
+      }
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -3092,6 +3172,15 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
+    },
+    "superstruct": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.6.1.tgz",
+      "integrity": "sha512-LDbOKL5sNbOJ00Q36iYRhSexKIptZje0/mhNznnz04wT9CmsPDZg/K/UV1dgYuCwNMuOBHTbVROZsGB9EhhK4w==",
+      "requires": {
+        "clone-deep": "^2.0.1",
+        "kind-of": "^6.0.1"
+      }
     },
     "supports-color": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.498.0",
-    "uuid": "^3.3.2"
+    "uuid": "^3.3.2",
+    "superstruct": "0.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   "dependencies": {
     "aws-sdk": "^2.498.0",
     "uuid": "^3.3.2",
-    "superstruct": "0.6.1"
+    "superstruct": "0.6.2"
   }
 }

--- a/tests/log-test.js
+++ b/tests/log-test.js
@@ -1,260 +1,168 @@
 'use strict';
 
 const assert = require('assert');
-
 const sandbox = require('sinon').createSandbox();
 
-const AWS = require('aws-sdk');
+const Firehose = require('../lib/firehose-wrapper');
 
-const putObjectStub = sandbox.stub();
-
-sandbox.stub(AWS, 'S3').returns({
-	putObject: putObjectStub
-});
-
-const Log = require('./../lib/log');
-const LogError = require('./../lib/log-error');
-
-const fakeLog = {
-	type: 1,
-	entity: 'api',
-	entity_id: 'product',
-	message: '[GET] Request from 0.0.0.0 a product/custom_data',
-	date_created: 1559103066,
-	user_created: 0,
-	log: {
-		uri: {
-			controller: 'product',
-			action: 'custom_data',
-			data: []
-		},
-		responseHttpCode: 200,
-		responseTime: '0.3236'
-	},
-	id: 'a1d2asd1-1a23-a23d-as1d-0asdas2130'
-};
-
-const expectedParams = {
-	Bucket: 'janis-trace-service-local',
-	Key: 'some-client/2019/05/29/some-service/api/a1d2asd1-1a23-a23d-as1d-0asdas2130.json',
-	Body: JSON.stringify({ ...fakeLog, service: 'some-service' }),
-	ContentType: 'application/json'
-};
-
-const setServiceEnvVars = () => {
-	process.env.JANIS_SERVICE_NAME = 'some-service';
-};
-
-const clearServiceEnvVars = () => {
-	delete process.env.JANIS_SERVICE_NAME;
-};
-
-const setStageEnvVars = () => {
-	process.env.JANIS_ENV = 'local';
-};
-
-const clearStageEnvVars = () => {
-	delete process.env.JANIS_ENV;
-};
-
-const clearCaches = () => {
-	delete Log._bucket; // eslint-disable-line
-};
+const Log = require('../lib/log');
 
 describe('Log', () => {
 
-	beforeEach(() => {
-		setServiceEnvVars();
-		setStageEnvVars();
-		putObjectStub.returns({
-			promise: () => {}
-		});
-	});
+	const fakeLog = {
+		id: 'some-log-id',
+		type: 'some-type',
+		entity: 'some-entity',
+		entityId: 'some-entity_id',
+		message: 'some-message',
+		log: {
+			some: 'log'
+		}
+	};
+
+	const expectedLog = {
+		id: fakeLog.id,
+		service: 'some-service',
+		entity: fakeLog.entity,
+		entityId: fakeLog.entityId,
+		type: fakeLog.type,
+		log: fakeLog.log,
+		message: fakeLog.message,
+		client: 'some-client'
+	};
+
+	const setServiceEnvVars = () => {
+		process.env.JANIS_SERVICE_NAME = 'some-service';
+	};
+
+	const clearServiceEnvVars = () => {
+		delete process.env.JANIS_SERVICE_NAME;
+	};
+
+	const setStageEnvVars = () => {
+		process.env.JANIS_ENV = 'local';
+	};
+
+	const clearStageEnvVars = () => {
+		delete process.env.JANIS_ENV;
+	};
+
+	const clearCaches = () => {
+		delete Log._deliveryStreamName; // eslint-disable-line no-underscore-dangle
+	};
 
 	afterEach(() => {
 		clearServiceEnvVars();
 		clearStageEnvVars();
-		sandbox.reset();
-	});
-
-	after(() => {
 		sandbox.restore();
 	});
 
-	describe('_validateLog', () => {
-
-		it('should not throw when the received log it\'s correct', async () => {
-			assert.doesNotThrow(() => Log._validateLog({ ...fakeLog, service: 'some-service' }));
-		});
-
-		['log', ['array']].forEach(log => {
-
-			it('should throw when the log is not an object or is an array', () => {
-
-				assert.throws(() => Log._validateLog(log), {
-					name: 'LogError',
-					code: LogError.codes.INVALID_LOG
-				});
-			});
-		});
-
-		context('when the received log doesn\'t have the required fields', () => {
-
-			it('should throw if log.entity not exists', async () => {
-				assert.throws(() => Log._validateLog({ type: 1 }), {
-					name: 'LogError',
-					code: LogError.codes.INVALID_LOG
-				});
-			});
-
-			it('should throw if log.type not exists', async () => {
-				assert.throws(() => Log._validateLog({ entity: 'some-entity' }), {
-					name: 'LogError',
-					code: LogError.codes.INVALID_LOG
-				});
-			});
-		});
-
-		context('when the received log fields have incorrect types', () => {
-
-			it('should throw if log.service is not a string', async () => {
-				assert.throws(() => Log._validateLog({ service: {} }), {
-					name: 'LogError',
-					code: LogError.codes.INVALID_LOG
-				});
-			});
-
-			it('should throw if log.entity is not a string', async () => {
-				assert.throws(() => Log._validateLog({ entity: 1, type: 2, service: 'some-service' }), {
-					name: 'LogError',
-					code: LogError.codes.INVALID_LOG
-				});
-			});
-
-			it('should throw if log.type is not a string or a number', async () => {
-				assert.throws(() => Log._validateLog({ entity: 'some-entity', type: {}, service: 'some-service' }), {
-					name: 'LogError',
-					code: LogError.codes.INVALID_LOG
-				});
-			});
-		});
+	beforeEach(() => {
+		setServiceEnvVars();
+		setStageEnvVars();
 	});
 
-	describe('add()', () => {
+	describe('add', () => {
 
-		it('should call S3.putObject when try to put a log into S3', async () => {
+		it('Should send a log to Firehose', async () => {
+
+			const fakeTime = sandbox.useFakeTimers(new Date().getTime());
+
+			sandbox.stub(Firehose.prototype, 'putRecord')
+				.returns();
 
 			await Log.add('some-client', fakeLog);
 
-			sandbox.assert.calledWithExactly(putObjectStub, expectedParams);
-			sandbox.assert.calledOnce(putObjectStub);
+			sandbox.assert.calledOnce(Firehose.prototype.putRecord);
+			sandbox.assert.calledWithExactly(Firehose.prototype.putRecord, {
+				DeliveryStreamName: 'janis-trace-firehose-local',
+				Record: {
+					Data: Buffer.from(JSON.stringify({ ...expectedLog, dateCreated: fakeTime.Date() }))
+				}
+			});
 		});
 
-		it('should publish the log to S3 using the specified service in log when log.service exists', async () => {
+		it('Should retry when Firehose fails', async () => {
+
+			const fakeTime = sandbox.useFakeTimers(new Date().getTime());
+
+			sandbox.stub(Firehose.prototype, 'putRecord')
+				.throws();
+
+			await Log.add('some-client', fakeLog);
+
+			sandbox.assert.calledThrice(Firehose.prototype.putRecord);
+
+			[0, 1, 2].forEach(call => {
+
+				sandbox.assert.calledWithExactly(Firehose.prototype.putRecord.getCall(call), {
+					DeliveryStreamName: 'janis-trace-firehose-local',
+					Record: {
+						Data: Buffer.from(JSON.stringify({ ...expectedLog, dateCreated: fakeTime.Date() }))
+					}
+				});
+			});
+		});
+
+		it('Should not call Firehose putRecord when ENV stage variable not exists', async () => {
+
+			clearStageEnvVars();
+			clearCaches();
+
+			sandbox.spy(Firehose.prototype, 'putRecord');
+
+			await Log.add('some-client', fakeLog);
+
+			sandbox.assert.notCalled(Firehose.prototype.putRecord);
+		});
+
+		it('Should not call Firehose putRecord when ENV service variable not exists', async () => {
 
 			clearServiceEnvVars();
+			clearCaches();
 
-			await Log.add('some-client', { ...fakeLog, service: 'some-service' });
-
-			sandbox.assert.calledWithExactly(putObjectStub, expectedParams);
-			sandbox.assert.calledOnce(putObjectStub);
-		});
-
-		it('should generate the log id and date_created when recieves a log without them', async () => {
-
-			const newFakeLog = { ...fakeLog };
-			delete newFakeLog.id;
-			delete newFakeLog.date_created;
-
-			await Log.add('some-client', newFakeLog);
-
-			const createdLog = JSON.parse(putObjectStub.lastCall.args[0].Body);
-
-			assert(createdLog.id && createdLog.date_created);
-
-			sandbox.assert.calledOnce(putObjectStub);
-		});
-
-		it('should retry when the S3 operation fail', async () => {
-
-			putObjectStub.returns({
-				promise: async () => { throw new Error(); }
-			});
-			putObjectStub.onCall(1).returns({
-				promise: () => {}
-			});
+			sandbox.spy(Firehose.prototype, 'putRecord');
 
 			await Log.add('some-client', fakeLog);
 
-			sandbox.assert.calledWithExactly(putObjectStub, expectedParams);
-			sandbox.assert.calledTwice(putObjectStub);
+			sandbox.assert.notCalled(Firehose.prototype.putRecord);
 		});
 
-		it('should emit \'create-error\' event when the S3 operation fails and max retries reached', async () => {
+		it('Should emit an error when something goes wrong', async () => {
 
-			let emitted;
+			let errorEmitted = false;
 
-			Log.on('create-error', (log, err) => {
-				if(log === fakeLog && err.name === 'LogError' && err.code === LogError.codes.S3_ERROR)
-					emitted = true;
+			Log.on('create-error', () => {
+				errorEmitted = true;
 			});
 
-			putObjectStub.returns({
-				promise: async () => { throw new Error(); }
-			});
+			await Log.add('some-client', { invalid: 'log' });
 
-			await Log.add('some-client', fakeLog);
-
-			sandbox.assert.calledWithExactly(putObjectStub, expectedParams);
-			sandbox.assert.callCount(putObjectStub, 3);
-			assert(emitted);
+			assert.deepEqual(errorEmitted, true);
 		});
 
-		it('should emit \'create-error\' event without calling S3.putObject when a LogError occurrs', async () => {
+		context('When the received log is invalid', () => {
 
-			let emitted;
+			[
 
-			Log.on('create-error', (log, err) => {
-				if(err.name === 'LogError' && err.code === LogError.codes.INVALID_LOG)
-					emitted = true;
-			});
+				{ ...fakeLog, entity: undefined },
+				{ ...fakeLog, entity: { not: 'a string' } },
+				{ ...fakeLog, entityId: ['not a number/string'] },
+				{ ...fakeLog, type: 1 },
+				{ ...fakeLog, log: 'not an object/array' },
+				{ ...fakeLog, message: { not: 'a string' } },
+				{ ...fakeLog, client: ['not a string'] },
+				{ ...fakeLog, userCreated: 1 }
 
-			await Log.add('some-client', { some: 'data' });
+			].forEach(log => {
 
-			sandbox.assert.notCalled(putObjectStub);
-			assert(emitted);
-		});
-	});
+				it('Should not call Firehose putRecord', async () => {
 
-	describe('_add()', () => {
+					sandbox.spy(Firehose.prototype, 'putRecord');
 
-		[null, ['client']].forEach(client => {
+					await Log.add('some-client', log);
 
-			it('should reject when the client is invalid', async () => {
-
-				await assert.rejects(Log._add(client, fakeLog), {
-					name: 'LogError',
-					code: LogError.codes.INVALID_CLIENT
-				});
-			});
-
-			it('should reject when the service name env not exists', async () => {
-
-				clearServiceEnvVars();
-				delete fakeLog.service;
-
-				await assert.rejects(Log._add('some-client', fakeLog), {
-					name: 'LogError',
-					code: LogError.codes.NO_SERVICE_NAME
-				});
-			});
-
-			it('should reject when the stage name env for bucket not exists', async () => {
-				clearStageEnvVars();
-				clearCaches();
-				await assert.rejects(Log._add('some-client', fakeLog), {
-					name: 'LogError',
-					code: LogError.codes.NO_STAGE_NAME
+					sandbox.assert.notCalled(Firehose.prototype.putRecord);
 				});
 			});
 		});


### PR DESCRIPTION
**JTR-57-FIREHOSE**
JTR-57 Modificar el package log para usar Firehose en vez de S3

**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JTR-57

**DESCRIPCIÓN DEL REQUERIMIENTO**
Las modificaciones solicitadas son:

- Eliminar la configuración de bucket
- En vez de usar AWS.S3 usar AWS.Firehose
- Donde envDeliveryStream debe ser
    - beta → JanisTraceFirehoseBeta
    - qa → JanisTraceFirehoseQA
    - prod → JanisTraceFirehoseProd
- La validación se debe hacer con superstruct
- Cambios de formato de log
    - type solo debe admitir String requerido
    - Se debe generar dateCreated en el momento, no se debe usar con el dato recibido en log
    - Crear el new Date() y luego formatearlo como UTC con toISOString()
    - Se debe agregar client en log.client, el dato se recibe en el primer parámetro del método 
      add(client, log).
    - Validar como String requerido
    - Validar userCreated como String opcional
    - En caso de re-intentar no se debe volver a formatear los datos, solo se debe re-intentar el putRecord()

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se desarrollaron los requerimientos solicitados