### PR TITLE
JCN-266-assume-role-expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Assume role expiration date validation
 
 ## [3.1.1] - 2020-04-23
 ### Added

--- a/lib/log.js
+++ b/lib/log.js
@@ -147,23 +147,28 @@ class Log {
 
 	static async getFirehoseInstance() {
 
-		const hasExpired = this._credentialsExpiration < new Date();
+		if(!this.validCredentials()) {
 
-		if(this._firehose && !hasExpired)
-			return this._firehose;
+			const firehoseParams = {
+				region: process.env.AWS_DEFAULT_REGION,
+				httpOptions: { timeout: MAX_TIMEOUT }
+			};
 
-		const firehoseParams = {
-			region: process.env.AWS_DEFAULT_REGION,
-			httpOptions: { timeout: MAX_TIMEOUT }
-		};
+			if(this.roleArn) {
+				firehoseParams.credentials = await this.getCredentials();
+				this.credentialsExpiration = new Date(firehoseParams.credentials.expiration);
+			}
 
-		if(this.roleArn) {
-			firehoseParams.credentials = await this.getCredentials();
-			this._credentialsExpiration = new Date(firehoseParams.credentials.expiration);
+			this.firehose = new Firehose(firehoseParams);
 		}
 
-		this._firehose = new Firehose(firehoseParams);
-		return this._firehose;
+		return this.firehose;
+	}
+
+	static validCredentials() {
+		return this.firehose
+			&& this.credentialsExpiration
+			&& this.credentialsExpiration >= new Date();
 	}
 
 	static async getCredentials() {

--- a/lib/log.js
+++ b/lib/log.js
@@ -159,7 +159,7 @@ class Log {
 
 		if(this.roleArn) {
 			firehoseParams.credentials = await this.getCredentials();
-			this._credentialsExpiration = firehoseParams.credentials.expiration;
+			this._credentialsExpiration = new Date(firehoseParams.credentials.expiration);
 		}
 
 		this._firehose = new Firehose(firehoseParams);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@janiscommerce/log",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tests/log-test.js
+++ b/tests/log-test.js
@@ -92,7 +92,7 @@ describe('Log', () => {
 			const fakeTime = sandbox.useFakeTimers(new Date().getTime());
 
 			sandbox.stub(STS.prototype, 'assumeRole')
-				.resolves({ ...fakeRole, Expiration: fakeTime.Date() });
+				.resolves({ ...fakeRole, Expiration: fakeTime.Date().toISOString() });
 
 			sandbox.stub(Firehose.prototype, 'putRecordBatch')
 				.resolves();
@@ -123,7 +123,7 @@ describe('Log', () => {
 			const fakeTime = sandbox.useFakeTimers(new Date().getTime());
 
 			sandbox.stub(STS.prototype, 'assumeRole')
-				.resolves({ ...fakeRole, Expiration: fakeTime.Date() });
+				.resolves({ ...fakeRole, Expiration: fakeTime.Date().toISOString() });
 
 			sandbox.stub(Firehose.prototype, 'putRecordBatch')
 				.resolves();
@@ -153,7 +153,7 @@ describe('Log', () => {
 			const fakeTime = sandbox.useFakeTimers(new Date().getTime());
 
 			sandbox.stub(STS.prototype, 'assumeRole')
-				.resolves({ ...fakeRole, Expiration: fakeTime.Date() });
+				.resolves({ ...fakeRole, Expiration: fakeTime.Date().toISOString() });
 
 			sandbox.stub(Firehose.prototype, 'putRecordBatch')
 				.resolves();
@@ -220,7 +220,7 @@ describe('Log', () => {
 			const fakeTime = sandbox.useFakeTimers(new Date().getTime());
 
 			sandbox.stub(STS.prototype, 'assumeRole')
-				.resolves({ ...fakeRole, Expiration: fakeTime.Date() });
+				.resolves({ ...fakeRole, Expiration: fakeTime.Date().toISOString() });
 
 			sandbox.stub(Firehose.prototype, 'putRecordBatch')
 				.throws();


### PR DESCRIPTION
**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-266

**DESCRIPCIÓN DEL REQUERIMIENTO**
Se encontró un BUG  en el cache interno de tiempo de expiración del AssumeRole

El error es que se esta comparando de la siguiente forma:
`const hasExpired = this._credentialsExpiration < new Date();`
Cuando la variable `this._credentialsExpiration` contiene un ISOString como por ejemplo `2020-05-12T15:58:47.031Z`.

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se corrigió la validación de las fechas de expiración y se corrigieron los tests para que se pruebe correctamente esto.