### PR TITLE
JCN-273-correcciones-del-package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Unit tests
+- Errors that was not handled correctly
 
 ## [3.1.2] - 2020-05-12
 ### Fixed

--- a/lib/log.js
+++ b/lib/log.js
@@ -121,7 +121,7 @@ class Log {
 
 			const firehose = await this.getFirehoseInstance();
 
-			return Promise.all(
+			await Promise.all(
 				logsBatches.map(logs => firehose.putRecordBatch(
 					{
 						DeliveryStreamName: this.deliveryStreamName,


### PR DESCRIPTION
**LINK AL TICKET**
[https://fizzmod.atlassian.net/browse/JCN-273](https://fizzmod.atlassian.net/browse/JCN-273)

**DESCRIPCIÓN DEL REQUERIMIENTO**
Se requiere arreglar el bug del método _add().

Se hace así… por este motivo no se ejecuta en este método.

```js
try {
  return Promise.all();
} catch(e) {}
```
Se debe hacer así… para que se ejecute en este método y funcione el catch si se necesita.

```js
try {
  await Promise.all();
} catch(e) {}
```

Mejorar los tests agregando el caso en que firehose falle pero se recupere antes de superar los reintentos y optimizar el codigo de los asserts.

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se arreglo el problema con el catch y se mejoraron los tests